### PR TITLE
Automate super-linter dependency updates

### DIFF
--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -32,5 +32,6 @@ jobs:
           || steps.metadata.outputs.dependency-names == 'actions/checkout'
           || steps.metadata.outputs.dependency-names == 'hashicorp/google'
           || steps.metadata.outputs.dependency-names == 'hashicorp/google-beta'
+          || steps.metadata.outputs.dependency-names == 'super-linter/super-linter'
         run: gh pr merge --auto --squash --delete-branch "${PR_URL}"
 ...


### PR DESCRIPTION
Add `super-linter/super-linter` to the set of automatically managed dependencies.